### PR TITLE
Update README.md for starting a simple HTTP server in Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,12 @@ The project is entirely static HTML, JS, and CSS. Enjoy!
 
 Clone this repo, then...
 ```
+# Navigate to the project's root directory
 cd pdf.js+hypothes.is
+# If using Python 2, start a simple HTTP server...
 python -m SimpleHTTPServer
+# ...or if using Python 3
+python -m http.server 8000
 # if you're on a Mac, do...
 open http://localhost:8000/web/viewer.html
 # if you're not, open your browser to that URL


### PR DESCRIPTION
Following the "Try it out!" instructions didn't work for me because I was using Python 3. A quick Google search solved my problem (see this StackOverflow question: http://stackoverflow.com/questions/17351016/set-up-python-simplehttpserver-on-windows), but it would be great if this information were available upfront.